### PR TITLE
Change join link to signup instead of login URL

### DIFF
--- a/_posts/2021-06-04-join.md
+++ b/_posts/2021-06-04-join.md
@@ -5,4 +5,4 @@ color: white   #text color
 fa-icon: key
 ---
 
-## Please join the [community](https://all-about-saas.slack.com)
+## Please join the [community](https://all-about-saas.slack.com/join/shared_invite/zt-qwvrywyr-8DmSpEzBiSWD2WQuB9r9pw#/shared-invite/email)


### PR DESCRIPTION
Current URL only works for existing members of the Slack workspace